### PR TITLE
cmake: remove find_package(ANSIC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,6 @@ check_include_files(sys/types.h HAVE_SYS_TYPES_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
 check_type_size("void*" SIZEOF_VOID_P)
 
-# TODO the AC_TYPE defines need porting
-find_package(ANSIC)
-
 # Trying to get the version of the package
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     find_package(Git)


### PR DESCRIPTION
ansi c is already set with CMAKE_C_STANDARD

warning was

```
CMake Warning at CMakeLists.txt:154 (find_package):
  By not providing "FindANSIC.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "ANSIC", but
  CMake did not find one.

  Could not find a package configuration file provided by "ANSIC" with any of
  the following names:

    ANSICConfig.cmake
    ansic-config.cmake
```
